### PR TITLE
use non-snapshot version of javax.ws.rs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
       <scope>provided</scope>
     </dependency>
       <dependency>
-          <groupId>unknown.binary</groupId>
-          <artifactId>javax.ws.rs-api-2.0</artifactId>
-          <version>SNAPSHOT</version>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>javax.ws.rs-api</artifactId>
+          <version>2.0.1</version>
       </dependency>
       <dependency>
           <groupId>org.glassfish.jersey.containers</groupId>


### PR DESCRIPTION
Snapshot versions tend to vanish from mvn repos.

Tested locally. Compiles ok:

    $ mvn -Prelease-profile install